### PR TITLE
Fix about page typo

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -8,7 +8,7 @@ enableComments = false
 +++
 
 Henrik Pettersson is best known as the Game Director of the time-bending Puzzle Adventure The Gardens Between. 
-He's currenly working as Senior Designer at Nightschool Studio / Netflix
+He's currently working as Senior Designer at Nightschool Studio / Netflix
 
 [Reach out on X](https://x.com/vghpe)
 


### PR DESCRIPTION
## Summary
- fix spelling in the About page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6872a8274c74832ba5b0c83a92718182