### PR TITLE
Rename first blog post to date-based slug

### DIFF
--- a/content/notes/2025_02_18-BlogApp.md
+++ b/content/notes/2025_02_18-BlogApp.md
@@ -31,17 +31,17 @@ set blogDir to "/Users/xxxx/blog/content/posts/"
 set imageDir to "images/" -- Hugo expects images here
 
 -- Generate date stamp
-set dateStamp to do shell script "date +%Y_%m_%d"
+set dateStamp to do shell script "date +%Y-%m-%d"
 
 -- Initialize counter
 set counter to 1
-set fileName to dateStamp & "-Untitled.md"
+set fileName to dateStamp & "-untitled.md"
 set filePath to blogDir & fileName
 
 -- Check if the file exists, and increment the counter
 repeat while (do shell script "test -e " & quoted form of filePath & "; echo $?") = "0"
 	set counter to counter + 1
-	set fileName to dateStamp & "-Untitled-" & counter & ".md"
+	set fileName to dateStamp & "-untitled-" & counter & ".md"
 	set filePath to blogDir & fileName
 end repeat
 

--- a/content/posts/2024-08-04-blog-deployed.md
+++ b/content/posts/2024-08-04-blog-deployed.md
@@ -2,6 +2,7 @@
 title: Blog deployed
 date: 2024-08-04T22:52:22-07:00
 draft: false
+slug: blog-deployed
 image: "images/IMG_2592.jpeg"
 ---
 


### PR DESCRIPTION
## Summary
- rename `Blog deployed.md` to `2024-08-04-blog-deployed.md`
- keep the original URL by adding `slug: blog-deployed`
- update AppleScript docs to produce hyphenated dates

## Testing
- `hugo --gc --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e7677634832b9d39a66c81f28ff1