### PR TITLE
Rename first blog post to date-based slug

### DIFF
--- a/content/posts/2024-08-04-blog-deployed.md
+++ b/content/posts/2024-08-04-blog-deployed.md
@@ -2,6 +2,8 @@
 title: Blog deployed
 date: 2024-08-04T22:52:22-07:00
 draft: false
+slug: blog-deployed
+aliases: ["/posts/blog-deployed/"]
 image: "images/IMG_2592.jpeg"
 ---
 

--- a/content/posts/2024-11-04-kojima-diary-study.md
+++ b/content/posts/2024-11-04-kojima-diary-study.md
@@ -1,6 +1,8 @@
 ---
 title: "Peeking into Kojima's Diary: Lessons in Creativity and Process" 
 date: 2024-11-04
+slug: kojima-diary-study
+aliases: ["/posts/KojimaDiaryStudy/"]
 draft: false 
 tags: ["Design", "Research", "game-dev"]
 image: "images/features/img_article_kojima-diary-closed.png"

--- a/content/posts/2025-02-22-media-literacy.md
+++ b/content/posts/2025-02-22-media-literacy.md
@@ -1,6 +1,8 @@
 ---
 title: "Media Literacy and Rhetorical Analysis of YouTube Rants"
 date: 2025-02-22T15:09:56
+slug: media-literacy
+aliases: ["/posts/2025_02_22-MediaLiteracy/"]
 draft: false
 tags: ["AI", "Tools"]
 ---


### PR DESCRIPTION
## Summary
- revert bulk renames
- rename "Blog deployed" to `2024-08-04-blog-deployed.md`
- add slug and alias for the new filename
- rename two more posts to date-based slugs

## Testing
- `hugo --gc --minify` *(fails: command not found)*
- `apt-get install hugo` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880e7677634832b9d39a66c81f28ff1