### PR TITLE
Add email reveal to about page via game

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -13,9 +13,10 @@ Over the past 14 years, he has designed games played by over 20 million people w
 
 Henrik is currently based in Sweden.
 
-[View Resume](/resume/Henrik_Pettersson_Resume.pdf)  
-[Reach out on X](https://x.com/vghpe)  
+[View Resume](/resume/Henrik_Pettersson_Resume.pdf)
+[Reach out on X](https://x.com/vghpe)
 [Reach out on Blue Sky](https://bsky.app/profile/vghpe.bsky.social)
+Email: <span id="jumptree-email">[jump over trees to show]</span>
 
 {{< jumptree >}}
 

--- a/layouts/shortcodes/jumptree.html
+++ b/layouts/shortcodes/jumptree.html
@@ -83,7 +83,7 @@
     <div id="tree2" class="tree" style="left: 65%;"></div>
     <button id="resetBtn">↻</button>
   </div>
-  <div id="message">Jump trees to see email. Tap inside game to jump</div>
+  <div id="message">Tap to jump</div>
 
   <script>
     // Tunables (60fps baseline for jump)
@@ -145,7 +145,7 @@
       player.style.left = playerX + 'px';
       player.style.bottom = jumpHeight + 'px';
       player.style.transform = 'scaleY(1) scaleX(1)';
-      message.innerHTML = 'Jump trees to see email. Tap inside game to jump';
+      message.innerHTML = 'Tap to jump';
       resetBtn.style.display = 'none';
       setFrozenStart(true);
       setTimeout(() => { setFrozenStart(false); }, START_FREEZE_TIME);
@@ -207,6 +207,10 @@
         if (playerX + player.offsetWidth >= game.offsetWidth) {
           const email = atob(encodedEmail);
           message.innerHTML = 'You did it! Email: <a href="mailto:' + email + '">' + email + '</a>';
+          const placeholder = document.getElementById('jumptree-email');
+          if (placeholder) {
+            placeholder.innerHTML = '<a href="mailto:' + email + '">' + email + '</a>';
+          }
           won = true;
           resetBtn.style.display = 'block';
         }


### PR DESCRIPTION
## Summary
- Add hidden email placeholder to About page
- Make jumptree game instructions say "Tap to jump" and reveal email on win

## Testing
- `npm test` (fails: Error: no test specified)
- `hugo` (command not found; apt-get update failed with 403)


------
https://chatgpt.com/codex/tasks/task_e_68a9b24457ac832b828b8ca3fb3c7531