### PR TITLE
Format about contacts and reveal email after game

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -13,10 +13,12 @@ Over the past 14 years, he has designed games played by over 20 million people w
 
 Henrik is currently based in Sweden.
 
-[View Resume](/resume/Henrik_Pettersson_Resume.pdf)
-[Reach out on X](https://x.com/vghpe)
-[Reach out on Blue Sky](https://bsky.app/profile/vghpe.bsky.social)
+<div id="contact-details">
+[View Resume](/resume/Henrik_Pettersson_Resume.pdf)<br>
+[Reach out on X](https://x.com/vghpe)<br>
+[Reach out on Blue Sky](https://bsky.app/profile/vghpe.bsky.social)<br>
 Email: <span id="jumptree-email">[jump over trees to show]</span>
+</div>
 
 {{< jumptree >}}
 

--- a/layouts/shortcodes/jumptree.html
+++ b/layouts/shortcodes/jumptree.html
@@ -84,6 +84,7 @@
     <button id="resetBtn">↻</button>
   </div>
   <div id="message">Tap to jump</div>
+  <div id="email-reveal"></div>
 
   <script>
     // Tunables (60fps baseline for jump)
@@ -103,6 +104,7 @@
     const tree2 = document.getElementById('tree2');
     const game = document.getElementById('game');
     const message = document.getElementById('message');
+    const emailReveal = document.getElementById('email-reveal');
     const resetBtn = document.getElementById('resetBtn');
 
     const encodedEmail = 'Z2cwMmhwZUBnbWFpbC5jb20=';
@@ -206,11 +208,15 @@
 
         if (playerX + player.offsetWidth >= game.offsetWidth) {
           const email = atob(encodedEmail);
-          message.innerHTML = 'You did it! Email: <a href="mailto:' + email + '">' + email + '</a>';
-          const placeholder = document.getElementById('jumptree-email');
-          if (placeholder) {
-            placeholder.innerHTML = '<a href="mailto:' + email + '">' + email + '</a>';
+          const emailLink = '<a href="mailto:' + email + '">' + email + '</a>';
+          const contactDetails = document.getElementById('contact-details');
+          if (contactDetails) {
+            contactDetails.innerHTML = 'Email: ' + emailLink;
           }
+          if (emailReveal) {
+            emailReveal.innerHTML = emailLink;
+          }
+          message.textContent = 'You did it.';
           won = true;
           resetBtn.style.display = 'block';
         }


### PR DESCRIPTION
## Summary
- Show a simple "You did it." message when the Jump Over Tree game is cleared
- Reveal the email below the game and replace contact links with the address after completion

## Testing
- `hugo --gc --minify` *(fails: command not found)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d13ae4b8832bba487b551f234d22