### PR TITLE
Fix about page links and email reveal

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -14,7 +14,7 @@ Over the past 14 years, he has designed games played by over 20 million people w
 Henrik is currently based in Sweden.
 
 <div id="contact-details">
-[View Resume](/resume/Henrik_Pettersson_Resume.pdf)<br>
+[View Resume]({{ "/resume/Henrik_Pettersson_Resume.pdf" | relURL }})<br>
 [Reach out on X](https://x.com/vghpe)<br>
 [Reach out on Blue Sky](https://bsky.app/profile/vghpe.bsky.social)<br>
 Email: <span id="jumptree-email">[jump over trees to show]</span>

--- a/layouts/shortcodes/jumptree.html
+++ b/layouts/shortcodes/jumptree.html
@@ -84,7 +84,6 @@
     <button id="resetBtn">↻</button>
   </div>
   <div id="message">Tap to jump</div>
-  <div id="email-reveal"></div>
 
   <script>
     // Tunables (60fps baseline for jump)
@@ -104,8 +103,8 @@
     const tree2 = document.getElementById('tree2');
     const game = document.getElementById('game');
     const message = document.getElementById('message');
-    const emailReveal = document.getElementById('email-reveal');
     const resetBtn = document.getElementById('resetBtn');
+    const emailSpan = document.getElementById('jumptree-email');
 
     const encodedEmail = 'Z2cwMmhwZUBnbWFpbC5jb20=';
 
@@ -208,13 +207,11 @@
 
         if (playerX + player.offsetWidth >= game.offsetWidth) {
           const email = atob(encodedEmail);
-          const emailLink = '<a href="mailto:' + email + '">' + email + '</a>';
-          const contactDetails = document.getElementById('contact-details');
-          if (contactDetails) {
-            contactDetails.innerHTML = 'Email: ' + emailLink;
-          }
-          if (emailReveal) {
-            emailReveal.innerHTML = emailLink;
+          if (emailSpan) {
+            const link = document.createElement('a');
+            link.href = 'mailto:' + email;
+            link.textContent = email;
+            emailSpan.replaceChildren(link);
           }
           message.textContent = 'You did it.';
           won = true;


### PR DESCRIPTION
## Summary
- Correct the resume URL on the About page so it resolves under the site base path.
- Update the Jump Tree game to reveal the email only in the existing placeholder and keep other contact links intact.

## Testing
- `npm test` *(fails: Error: no test specified)*
- `hugo --version` *(command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d4f2ab28832bbcfc392fe10439be