### PR TITLE
Fix resume link on About page

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -13,7 +13,7 @@ Over the past 14 years, he has designed games played by over 20 million people w
 
 Henrik is currently based in Sweden.
 
-- [View Resume]({{ "/resume/Henrik_Pettersson_Resume.pdf" | relURL }})
+- [View Resume](/resume/Henrik_Pettersson_Resume.pdf)
 - [Reach out on X](https://x.com/vghpe)
 - [Reach out on Blue Sky](https://bsky.app/profile/vghpe.bsky.social)
 - Email: <span id="jumptree-email">&lt;jump over trees to show&gt;</span>


### PR DESCRIPTION
## Summary
- Fix broken Resume link on the About page to point directly to the PDF file.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e57e3330832bacc7dd01ab5cba88