### PR TITLE
Update base URL and add Hugo aliases for legacy /blog paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # blog
 
-[Visit the blog](https://vghpe.github.io/blog/)
+[Visit the blog](https://vghpe.github.io/)
 
 This repository contains the source for my personal site built with Hugo and IndieKit.
 

--- a/content/docs/extended-documentation.md
+++ b/content/docs/extended-documentation.md
@@ -30,7 +30,7 @@ Micropub posts can syndicate to Bluesky through the `@indiekit/syndicator-bluesk
 | Variable           | Description                                                        |
 | ------------------ | ------------------------------------------------------------------ |
 | `MONGODB_URL`      | MongoDB connection string (e.g. `mongodb+srv://…`). Required when using Indiekit's queue or token storage features.
-| `PUBLICATION_ME`   | Canonical site URL (e.g. `https://vghpe.github.io/blog/`).
+| `PUBLICATION_ME`   | Canonical site URL (e.g. `https://vghpe.github.io/`).
 | `BLUESKY_HANDLE`   | Bluesky handle (e.g. `vghpe.bsky.social`).
 | `BLUESKY_PASSWORD` | Bluesky app password for the Micropub syndicator.
 | `GITHUB_USER`      | GitHub username for the GitHub store plugin.
@@ -52,7 +52,7 @@ application:
   mongodbUrl: "mongodb://127.0.0.1:27017/indiekit"
 
 publication:
-  me: "https://vghpe.github.io/blog/"
+  me: "https://vghpe.github.io/"
 
 plugins:
   - '@indiekit/store-file-system'

--- a/content/posts/2024-08-04-blog-deployed.md
+++ b/content/posts/2024-08-04-blog-deployed.md
@@ -5,6 +5,7 @@ draft: true
 slug: blog-deployed
 aliases:
   - /posts/blog-deployed/
+  - /blog/posts/blog-deployed/
 image: images/IMG_2592.jpeg
 ---
 

--- a/content/posts/2024-08-04-making-this-blog.md
+++ b/content/posts/2024-08-04-making-this-blog.md
@@ -5,6 +5,7 @@ draft: true
 slug: making-this-blog
 aliases:
   - /posts/makingthisblog/
+  - /blog/posts/makingthisblog/
 image: /images/IMG_2590.jpg
 tags: []
 ---

--- a/content/posts/2024-08-11-saving-your-references.md
+++ b/content/posts/2024-08-11-saving-your-references.md
@@ -5,6 +5,7 @@ draft: false
 slug: saving-your-references
 aliases:
   - /posts/saving-your-references/
+  - /blog/posts/saving-your-references/
 tags:
   - tool
 ---

--- a/content/posts/2024-08-18-outrage-content.md
+++ b/content/posts/2024-08-18-outrage-content.md
@@ -5,6 +5,7 @@ draft: true
 slug: outrage-content
 aliases:
   - /posts/outrage-content/
+  - /blog/posts/outrage-content/
 tags: []
 image: images/IMG_2639-2.jpeg
 ---

--- a/content/posts/2024-08-27-mgs2-revisit.md
+++ b/content/posts/2024-08-27-mgs2-revisit.md
@@ -5,6 +5,7 @@ draft: false
 slug: mgs2-revisit
 aliases:
   - /posts/mgs2-revisit-/
+  - /blog/posts/mgs2-revisit-/
 tags:
   - journal
 image: images/IMG_2703.jpeg

--- a/content/posts/2024-08-28-image-stitch.md
+++ b/content/posts/2024-08-28-image-stitch.md
@@ -5,6 +5,7 @@ draft: false
 slug: image-stitch
 aliases:
   - /posts/image_stitch/
+  - /blog/posts/image_stitch/
 tags:
   - tool
 image: images/stitch.png

--- a/content/posts/2024-09-01-evil-apes-dukin-it-out-on-a-giant-ball.md
+++ b/content/posts/2024-09-01-evil-apes-dukin-it-out-on-a-giant-ball.md
@@ -5,6 +5,7 @@ draft: false
 slug: evil-apes-dukin-it-out-on-a-giant-ball
 aliases:
   - /posts/evil-apes-dukin-it-out-on-a-giant-ball/
+  - /blog/posts/evil-apes-dukin-it-out-on-a-giant-ball/
 tags:
   - narrative
 image: images/IMG_2718.jpeg

--- a/content/posts/2024-09-02-sneaky-hallucinations.md
+++ b/content/posts/2024-09-02-sneaky-hallucinations.md
@@ -3,7 +3,9 @@ title: Sneaky hallucinations
 date: 2024-09-02T23:35:39-07:00
 draft: true
 slug: 'sneaky-hallucinations'
-aliases: ["/posts/sneaky-hallucinations-/"]
+aliases:
+  - /posts/sneaky-hallucinations-/
+  - /blog/posts/sneaky-hallucinations-/
 tags: ["research", "AI"]
 image: "images/IMG_2727.jpeg"
 ---

--- a/content/posts/2024-09-14-ai-translation.md
+++ b/content/posts/2024-09-14-ai-translation.md
@@ -5,6 +5,7 @@ draft: false
 slug: ai-translation
 aliases:
   - /posts/2024-09-14-ai-translation/
+  - /blog/posts/2024-09-14-ai-translation/
 tags:
   - research
   - AI
@@ -14,7 +15,7 @@ Kojima's dev-diary was originally published in the book *Metal Gear Solid 2: The
 
 After some online sleuthing, I discovered that the entire content had been [uploaded to X](https://x.com/BadHumans/status/1744883721595924822). Can I use AI to translate it? <!--more-->
 
-**Update:** I was able to source a Human Translation of the diary, Read more [here](https://vghpe.github.io/blog/posts/human-translation/)  
+**Update:** I was able to source a Human Translation of the diary, Read more [here](/posts/human-translation/)
 
 I have previously used ChatGPT for various translation tasks and was impressed with its ability. Its translation of Swedish (my native language) was able to capture even the most obscure nuances, and it has been a super helpful tool as I’ve been learning Vietnamese. So, I was curious to try it out on the scans and gain insight into this never-before-translated Kojima Diary.
 

--- a/content/posts/2024-09-28-twitter.md
+++ b/content/posts/2024-09-28-twitter.md
@@ -5,6 +5,7 @@ draft: true
 slug: twitter
 aliases:
   - /posts/twitter/
+  - /blog/posts/twitter/
 tweet: https://twitter.com/anime_twits/status/1838862257821777937
 tags: []
 ---

--- a/content/posts/2024-11-03-human-translation.md
+++ b/content/posts/2024-11-03-human-translation.md
@@ -5,6 +5,7 @@ draft: false
 slug: human-translation
 aliases:
   - /posts/human-translation/
+  - /blog/posts/human-translation/
 tags:
   - research
   - AI
@@ -12,7 +13,7 @@ image: images/kojima-drawing-inverted.jpg
 ---
 I was able source a translation of Kojima's diary that was done commissioned by the youtube channel *Did You Know Gaming?* After I completed my own AI translation and began working on an article, it arrived in my inbox. How does it compare to the AI version? <!--more-->
 
-[Go here](https://vghpe.github.io/blog/posts/ai-translation/) to read the previous entry 
+[Go here](/posts/ai-translation/) to read the previous entry
 
 I wanted to see just how accurate the chatbots had been—and, more importantly, to gain greater confidence in my understanding and takeaways. On initial examination, I noticed some differences in language and tone, as well as a few concerning inconsistencies.
 

--- a/content/posts/2024-11-04-kojima-diary-study.md
+++ b/content/posts/2024-11-04-kojima-diary-study.md
@@ -4,6 +4,7 @@ date: 2024-11-04
 slug: kojima-diary-study
 aliases:
   - /posts/kojimadiarystudy/
+  - /blog/posts/kojimadiarystudy/
 draft: false
 tags:
   - article

--- a/content/posts/2024-12-15-traditionalist.md
+++ b/content/posts/2024-12-15-traditionalist.md
@@ -4,6 +4,7 @@ date: 2024-12-15T12:00:00Z
 slug: traditionalist
 aliases:
   - /posts/traditionalist/
+  - /blog/posts/traditionalist/
 draft: false
 tags:
   - research

--- a/content/posts/2025-01-02-compare-dilalogue.md
+++ b/content/posts/2025-01-02-compare-dilalogue.md
@@ -8,6 +8,7 @@ image: images/arranger-short-title.png
 slug: compare-dilalogue
 aliases:
   - /posts/compare_dilalogue/
+  - /blog/posts/compare_dilalogue/
 draft: false
 ---
 

--- a/content/posts/2025-01-22-first-unity-export-test.md
+++ b/content/posts/2025-01-22-first-unity-export-test.md
@@ -6,6 +6,7 @@ tags:
 slug: first-unity-export-test
 aliases:
   - /posts/first_unity_export_test/
+  - /blog/posts/first_unity_export_test/
 ---
 
 <div style="display:flex; justify-content:center; margin-bottom:20px; overflow:hidden;">

--- a/content/posts/2025-02-22-media-literacy.md
+++ b/content/posts/2025-02-22-media-literacy.md
@@ -5,6 +5,8 @@ slug: media-literacy
 aliases:
   - /posts/2025_02_22-mediaLiteracy/
   - /posts/2025_02_22-medialiteracy/
+  - /blog/posts/2025_02_22-mediaLiteracy/
+  - /blog/posts/2025_02_22-medialiteracy/
 draft: false
 tags:
   - tool

--- a/content/posts/2025-07-17-flcl-creative-process.md
+++ b/content/posts/2025-07-17-flcl-creative-process.md
@@ -5,6 +5,7 @@ draft: false
 slug: flcl-creative-process
 aliases:
   - /posts/2025-07-17-flcl-creative-process/
+  - /blog/posts/2025-07-17-flcl-creative-process/
 tags:
   - article
   - research

--- a/content/posts/2025-08-13-narrative-outline-9-platforms.md
+++ b/content/posts/2025-08-13-narrative-outline-9-platforms.md
@@ -3,7 +3,9 @@ title: "9 Platforms - Narrative Outline v1"
 date: 2025-08-13T13:17:00
 draft: false
 slug: nine-platforms-rev1
-aliases: 
+aliases:
+  - /posts/nine-platforms-rev1/
+  - /blog/posts/nine-platforms-rev1/
 tags:
   - narrative
 image: images/nine-platfoms-town_1.gif

--- a/content/posts/2025-08-23-twitter-dl-guide.md
+++ b/content/posts/2025-08-23-twitter-dl-guide.md
@@ -4,6 +4,8 @@ date: 2025-08-25T13:17:00
 draft: false
 slug: twitter-dl-guide
 aliases:
+  - /posts/twitter-dl-guide/
+  - /blog/posts/twitter-dl-guide/
 tags:
   - documentation
   - tool

--- a/docs/Indiekit_documentation.md
+++ b/docs/Indiekit_documentation.md
@@ -1,6 +1,6 @@
 # IndieKit + Hugo + GitHub Pages (+ Bluesky)
 
-A reproducible runbook for the stack that powers [vghpe.github.io/blog](https://vghpe.github.io/blog).
+A reproducible runbook for the stack that powers [vghpe.github.io](https://vghpe.github.io).
 
 ---
 
@@ -31,7 +31,7 @@ A reproducible runbook for the stack that powers [vghpe.github.io/blog](https://
 | Key                   | Description / Example                      |
 | --------------------- | ------------------------------------------ |
 | `MONGODB_URL`         | `mongodb+srv://user:pass@cluster0...`      |
-| `PUBLICATION_ME`      | `https://vghpe.github.io/blog/`            |
+| `PUBLICATION_ME`      | `https://vghpe.github.io/`            |
 | `GITHUB_USER`         | `vghpe`                                    |
 | `GITHUB_REPO`         | `blog`                                     |
 | `GITHUB_BRANCH`       | `main` (default)                           |

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = "https://vghpe.github.io/blog/"
+baseURL = "https://vghpe.github.io/"
 title = "vghpe"
 relativeURLs = false
 canonifyURLs = true


### PR DESCRIPTION
## Summary
- point the Hugo configuration and documentation to https://vghpe.github.io/
- add /blog-prefixed aliases to long-form posts so old links continue to resolve

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfdcd6d5f8832baf9b3defe42cbe48